### PR TITLE
Update error handling to handle boolean response

### DIFF
--- a/breeze/breeze.py
+++ b/breeze/breeze.py
@@ -103,7 +103,7 @@ class BreezeApi(object):
         try:
             response = response.json()
         except requests.ConnectionError as error:
-            raise BreezeError(error.message)
+            raise BreezeError(error)
         else:
             if not self._request_succeeded(response):
                 raise BreezeError(response)
@@ -112,7 +112,10 @@ class BreezeApi(object):
 
     def _request_succeeded(self, response):
         """Predicate to ensure that the HTTP request succeeded."""
-        return not (('errors' in response) or ('errorCode' in response))
+        if isinstance(response, bool):
+            return response
+        else:
+            return not (('errors' in response) or ('errorCode' in response))
 
     def get_people(self, limit=None, offset=None, details=False):
         """List people from your database.

--- a/tests/breeze_test.py
+++ b/tests/breeze_test.py
@@ -398,6 +398,24 @@ class BreezeApiTestCase(unittest.TestCase):
             '%s%s/list_campaigns' % (FAKE_SUBDOMAIN,
                                      breeze.ENDPOINTS.PLEDGES))
 
+    def test_false_response(self):
+        response = MockResponse(200, json.dumps(False))
+        connection = MockConnection(response)
+        breeze_api = breeze.BreezeApi(
+            breeze_url=FAKE_SUBDOMAIN,
+            api_key=FAKE_API_KEY,
+            connection=connection)
+        self.assertRaises(breeze.BreezeError, lambda: breeze_api.event_check_in('1', '2'))
+
+    def test_errors_response(self):
+        response = MockResponse(200, json.dumps({'errors': 'Some Errors'}))
+        connection = MockConnection(response)
+        breeze_api = breeze.BreezeApi(
+            breeze_url=FAKE_SUBDOMAIN,
+            api_key=FAKE_API_KEY,
+            connection=connection)
+        self.assertRaises(breeze.BreezeError, lambda: breeze_api.event_check_in('1', '2'))
+
     def test_list_pledges(self):
         response = MockResponse(200, json.dumps([{
             "id": "12345",


### PR DESCRIPTION
Some endpoints return a boolean `false` on error which was not reported as an error. One such example is https://www.breezechms.com/api#add_volunteer. If the response is of type `boolean`, raise `BreezeError`.